### PR TITLE
feat: add optional integrator field and update backend submission

### DIFF
--- a/index.html
+++ b/index.html
@@ -274,6 +274,10 @@
                         <input type="text" id="user-company" name="user-company" required>
                     </div>
                     <div class="form-group">
+                        <label for="user-integrator">系統整合服務商</label>
+                        <input type="text" id="user-integrator" name="user-integrator">
+                    </div>
+                    <div class="form-group">
                         <label for="user-title">職務<span class="required">*</span></label>
                         <input type="text" id="user-title" name="user-title" required>
                     </div>
@@ -304,6 +308,7 @@
                 contactPhone: document.getElementById('user-contact-phone').value.trim(),
                 mobilePhone: document.getElementById('user-mobile-phone').value.trim(),
                 company: document.getElementById('user-company').value.trim(),
+                integrator: document.getElementById('user-integrator').value.trim(),
                 title: document.getElementById('user-title').value.trim(),
                 email: document.getElementById('user-email').value.trim(),
             };

--- a/questionnaire.html
+++ b/questionnaire.html
@@ -219,7 +219,7 @@
                                     </ul>
                                 </div>
                                 <div class="">
-                                    <h3 class="text-lg font-bold mb-4 text-white">2. 如果想了解更多可視性控管或相關技術趨勢和應用，請聯繫Gigamon代理商逸盈科技</h3>
+                                    <h3 class="text-lg font-bold mb-4 text-white">2. 如果想了解更多可視性控管或相關技術趨勢和應用，請聯繫您的Gigamon授權經銷商窗口</h3>
                                     <ul class="list-disc list-inside space-y-2 pl-4 text-gray-300">
                                         <li>客服中心 (02) 6636 - 8889</li>
                                     </ul>

--- a/questionnaire.js
+++ b/questionnaire.js
@@ -677,7 +677,11 @@ const submitStatusEl = document.getElementById('submit-status');
         const payload = {
             type: 'pdf',
             userName: userInfo.name,
+            userContactPhone: userInfo.contactPhone,
+            userMobilePhone: userInfo.mobilePhone,
             userCompany: userInfo.company,
+            userIntegrator: userInfo.integrator,
+            userTitle: userInfo.title,
             userEmail: userInfo.email,
             pdfBase64: base64
         };
@@ -708,6 +712,8 @@ const submitStatusEl = document.getElementById('submit-status');
             userContactPhone: userInfo.contactPhone,
             userMobilePhone: userInfo.mobilePhone,
             userCompany: userInfo.company,
+            userIntegrator: userInfo.integrator,
+            userTitle: userInfo.title,
             userEmail: userInfo.email,
             answers: answerTexts
         };


### PR DESCRIPTION
## Summary
- add optional system integrator field to the assessment form and store its value
- update final page messaging to refer users to their authorized Gigamon reseller
- include all seven form fields when submitting results to Google Apps Script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c5f93fa7c83229331de4deaf94766