### PR TITLE
feat: add optional integrator field and update backend submission

### DIFF
--- a/index.html
+++ b/index.html
@@ -281,6 +281,10 @@
                         <label for="user-email">電子郵件<span class="required">*</span></label>
                         <input type="email" id="user-email" name="user-email" required>
                     </div>
+                    <div class="form-group">
+                        <label for="user-integrator">系統整合服務商</label>
+                        <input type="text" id="user-integrator" name="user-integrator">
+                    </div>
                     <div class="form-check">
                         <input type="checkbox" id="privacy-check" required>
                         <span class="privacy-text">我同意逸盈科技依據隱私權政策蒐集、處理並使用本人提供的個人資料，用於此次免費服務與後續 Gigamon 相關產品與活動資訊通知。</span>
@@ -306,6 +310,7 @@
                 company: document.getElementById('user-company').value.trim(),
                 title: document.getElementById('user-title').value.trim(),
                 email: document.getElementById('user-email').value.trim(),
+                integrator: document.getElementById('user-integrator').value.trim(),
             };
 
             // 1. 檢查所有必填欄位和隱私權同意

--- a/questionnaire.html
+++ b/questionnaire.html
@@ -219,7 +219,7 @@
                                     </ul>
                                 </div>
                                 <div class="">
-                                    <h3 class="text-lg font-bold mb-4 text-white">2. 如果想了解更多可視性控管或相關技術趨勢和應用，請聯繫Gigamon代理商逸盈科技</h3>
+                                    <h3 class="text-lg font-bold mb-4 text-white">2. 如果想了解更多可視性控管或相關技術趨勢和應用，請聯繫您的Gigamon授權經銷商窗口</h3>
                                     <ul class="list-disc list-inside space-y-2 pl-4 text-gray-300">
                                         <li>客服中心 (02) 6636 - 8889</li>
                                     </ul>

--- a/questionnaire.js
+++ b/questionnaire.js
@@ -677,7 +677,11 @@ const submitStatusEl = document.getElementById('submit-status');
         const payload = {
             type: 'pdf',
             userName: userInfo.name,
+            userContactPhone: userInfo.contactPhone,
+            userMobilePhone: userInfo.mobilePhone,
             userCompany: userInfo.company,
+            userIntegrator: userInfo.integrator,
+            userTitle: userInfo.title,
             userEmail: userInfo.email,
             pdfBase64: base64
         };
@@ -708,6 +712,8 @@ const submitStatusEl = document.getElementById('submit-status');
             userContactPhone: userInfo.contactPhone,
             userMobilePhone: userInfo.mobilePhone,
             userCompany: userInfo.company,
+            userIntegrator: userInfo.integrator,
+            userTitle: userInfo.title,
             userEmail: userInfo.email,
             answers: answerTexts
         };


### PR DESCRIPTION
## Summary
- add optional system integrator field to the assessment form and store its value
- update final page messaging to refer users to their authorized Gigamon reseller
- include all seven form fields when submitting results to Google Apps Script
- move optional system integrator field to the end of the form

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c5f93fa7c83229331de4deaf94766